### PR TITLE
Restore concessioni action modals

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -277,24 +277,25 @@ mark.hl { background: #fff59d; color: inherit; padding: 0 2px; border-radius: 2p
     position: fixed; inset: 0; background: rgba(5,8,16,.45);
     display: none; z-index: 1000; padding: 24px; overflow: auto;
 }
-.modal .content {
+.modal .modal-content {
     background: var(--glass-bg); color: var(--md-sys-on-surface);
     border-radius: 16px; border: 1px solid var(--glass-border);
     margin: auto; padding: 0; max-width: 1100px; box-shadow: var(--glass-shadow);
 }
-.modal .header, .modal .footer { padding: 12px 16px; border-bottom: 1px solid var(--md-sys-outline); }
-.modal .footer { border-bottom: 0; border-top: 1px solid var(--md-sys-outline); display: flex; gap: 8px; justify-content: flex-end; }
-.modal .close { position: absolute; top: 12px; right: 12px; border: 0; background: transparent; font-size: 24px; cursor: pointer; }
+.modal .modal-content.modal-xl { max-width: 1200px; }
+.modal-header, .modal-footer { padding: 12px 16px; border-bottom: 1px solid var(--md-sys-outline); }
+.modal-footer { border-bottom: 0; border-top: 1px solid var(--md-sys-outline); display: flex; gap: 8px; justify-content: flex-end; }
+.modal-close { position: absolute; top: 12px; right: 12px; border: 0; background: transparent; font-size: 24px; cursor: pointer; }
 
 /* Accordion (generica) */
-.accordion .item { border-top: 1px solid var(--md-sys-outline); }
-.accordion .item:first-child { border-top: 0; }
-.accordion .header {
+.accordion-item { border-top: 1px solid var(--md-sys-outline); }
+.accordion-item:first-child { border-top: 0; }
+.accordion-header {
   width: 100%; text-align: left; background: var(--md-sys-surface);
   border: 0; padding: 12px 14px; font-weight: 600; display: flex; justify-content: space-between; align-items: center; cursor: pointer;
 }
-.accordion .header.open { background: color-mix(in oklab, var(--md-sys-surface), #000 6%); }
-.accordion .panel { display: none; padding: 12px 16px; }
+.accordion-header.open { background: color-mix(in oklab, var(--md-sys-surface), #000 6%); }
+.accordion-panel { display: none; padding: 12px 16px; }
 
 /* Form rows */
 .form-row { display: grid; gap: 6px; margin-bottom: 10px; }

--- a/templates/concessioni.php
+++ b/templates/concessioni.php
@@ -116,33 +116,3 @@
     <?php endif; ?>
 </div>
 
-<!-- Modali -->
-<div id="detailModal" class="modal" style="display:none;">
-    <div class="modal-content">
-        <button class="modal-close" data-close="detailModal" title="Chiudi" type="button">&times;</button>
-        <div class="modal-grid">
-            <aside class="modal-nav">
-                <ul id="detailMenu"></ul>
-            </aside>
-            <section class="modal-body">
-                <div id="detailHeader" class="detail-header"></div>
-                <div id="detailContent" class="detail-content"></div>
-            </section>
-        </div>
-    </div>
-</div>
-
-<div id="editModal" class="modal" style="display:none;">
-    <div class="modal-content modal-xl">
-        <button class="modal-close" data-close="editModal" title="Chiudi" type="button">&times;</button>
-        <header class="modal-header">
-            <h3><i class="fa-regular fa-pen-to-square"></i> Modifica Concessione</h3>
-            <small id="editSubtitle" class="subtitle"></small>
-        </header>
-        <div id="editAccordion" class="accordion"></div>
-        <footer class="modal-footer">
-            <button id="btnSaveEdit" class="btn btn-primary" type="button"><i class="fa-solid fa-floppy-disk"></i> Salva</button>
-            <button class="btn" data-close="editModal" type="button"><i class="fa-solid fa-xmark"></i> Annulla</button>
-        </footer>
-    </div>
-</div>

--- a/templates/partials/modals.php
+++ b/templates/partials/modals.php
@@ -1,37 +1,33 @@
 <?php // /templates/partials/modals.php ?>
-<div class="modal-overlay" id="detailsModal">
-    <div class="modal-container">
-        <div class="modal-header">
-            <div>
-                <h2 id="modalTitle">Dettagli SID</h2>
-                <div id="modalSubtitle" class="modal-subtitle"></div>
-            </div>
-            <button class="modal-close-btn">&times;</button>
-        </div>
-        <div class="modal-body">
-            <nav class="modal-nav" id="modalNav"></nav>
-            <div class="modal-content" id="modalContent"></div>
+
+<!-- Modale dettaglio viste materializzate -->
+<div id="detailModal" class="modal" style="display:none;">
+    <div class="modal-content">
+        <button class="modal-close" data-close="detailModal" title="Chiudi" type="button">&times;</button>
+        <div class="modal-grid">
+            <aside class="modal-nav">
+                <ul id="detailMenu"></ul>
+            </aside>
+            <section class="modal-body">
+                <div id="detailHeader" class="detail-header"></div>
+                <div id="detailContent" class="detail-content"></div>
+            </section>
         </div>
     </div>
 </div>
 
-<div class="modal-overlay" id="editModal">
-    <div class="modal-container">
-        <div class="modal-header">
-            <div>
-                <h2 id="editTitle">Modifica Concessione</h2>
-                <div id="editSubtitle" class="modal-subtitle"></div>
-            </div>
-            <button class="modal-close-btn">&times;</button>
-        </div>
-        <div class="modal-content" id="editModalContent">
-            <div id="editAlert" style="display:none;"></div>
-            <form id="editForm"></form>
-        </div>
-        <div class="modal-footer">
-            <button class="btn" type="button" id="editCancelBtn">Annulla</button>
-            <button class="btn" type="button" id="editSaveContinueBtn"><i class="fas fa-save"></i> Salva e continua</button>
-            <button class="btn btn-primary" type="button" id="editSaveExitBtn"><i class="fas fa-check"></i> Salva ed esci</button>
-        </div>
+<!-- Modale modifica concessione -->
+<div id="editModal" class="modal" style="display:none;">
+    <div class="modal-content modal-xl">
+        <button class="modal-close" data-close="editModal" title="Chiudi" type="button">&times;</button>
+        <header class="modal-header">
+            <h3><i class="fa-regular fa-pen-to-square"></i> Modifica Concessione</h3>
+            <small id="editSubtitle" class="subtitle"></small>
+        </header>
+        <div id="editAccordion" class="accordion"></div>
+        <footer class="modal-footer">
+            <button id="btnSaveEdit" class="btn btn-primary" type="button"><i class="fa-solid fa-floppy-disk"></i> Salva</button>
+            <button class="btn" data-close="editModal" type="button"><i class="fa-solid fa-xmark"></i> Annulla</button>
+        </footer>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- move the concessioni detail and edit modals into the shared partial that is always loaded with the layout
- update the modal and accordion styles to match the new markup so the detail and edit dialogs render correctly

## Testing
- php -l templates/concessioni.php
- php -l templates/partials/modals.php

------
https://chatgpt.com/codex/tasks/task_b_68d04a689aa4832286bd567403933448